### PR TITLE
Add CORS support to simplify development of GSL  Editor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,5 @@ WORKDIR /app/gsl_api
 
 RUN apt-get install -y python3 python3-pip
 RUN pip3 install -r requirements.txt
+RUN mkdir /gsl-tmp-output
 

--- a/gsl_api/apps/gslrun/wrapper.py
+++ b/gsl_api/apps/gslrun/wrapper.py
@@ -47,19 +47,13 @@ class GSLWrapper(object):
             output_json_path
         ]
 
-        stdout_fp = open(stdout_path, 'w+')
-        stderr_fp = open(stderr_path, 'w+')
-
-        result = subprocess.Popen(
-            args,
-            stdout=stdout_fp,
-            stderr=stderr_fp,
-            cwd=cwd_path)
-
-        stdout_fp.close()
-        stderr_fp.close()
-
-        return result
+        with open(stdout_path, 'w+') as stdout_fp:
+            with open(stderr_path, 'w+') as stderr_fp:
+                subprocess.Popen(
+                    args,
+                    stdout=stdout_fp,
+                    stderr=stderr_fp,
+                    cwd=cwd_path)
 
     def list_reference_genomes(self):
         working_path = self.settings.get('gsl_base_path', None)

--- a/gsl_api/config/settings.py
+++ b/gsl_api/config/settings.py
@@ -37,10 +37,12 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
+    'corsheaders',
     'gslrun',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/gsl_api/config/settings_dev.py
+++ b/gsl_api/config/settings_dev.py
@@ -9,3 +9,7 @@ GSL_OPTIONS = {
     'gsl_base_path': '/app/Gslc', # folder containing gslc_lib
     'gsl_compiler_path': '/app/Gslc/bin/Gslc/Gslc.exe'
 }
+
+CORS_ORIGIN_WHITELIST = [
+    "http://localhost:8080",
+]

--- a/gsl_api/requirements.txt
+++ b/gsl_api/requirements.txt
@@ -1,3 +1,4 @@
 Django>=2.0
 django-rest-framework
+django-cors-headers
 gunicorn


### PR DESCRIPTION
Started an editor: 
https://github.com/Yzupnick/gsl-editor

Doesn't do much right now, it instantiates [monaco editor](https://microsoft.github.io/monaco-editor/) with some valid GSL, and exposes a "compile" button that hits your service api with the contents of the editor.

It works!! It can use some syntax highlighting, design, a useful response, etc...